### PR TITLE
Modelwizard

### DIFF
--- a/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/modelwizard/pages/ElementGeneratorWizardPage.java
+++ b/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/modelwizard/pages/ElementGeneratorWizardPage.java
@@ -199,18 +199,14 @@ public class ElementGeneratorWizardPage extends WizardPage {
 					if (event.keyCode == SWT.CR && currentColumn%2 == 0 && currentColumn != 0) {
 						return true;
 					}
-					if (isNameColumn && ((event.keyCode >= 48 && event.keyCode <= 57) || (event.keyCode >= 97 && event.keyCode <= 122))) {
+					//if (isNameColumn && ((event.keyCode >= 48 && event.keyCode <= 57) || (event.keyCode >= 97 && event.keyCode <= 122))) {
+					if (isNameColumn && event.eventType == ColumnViewerEditorActivationEvent.KEY_PRESSED && isNotDifferentUsedKey(event.keyCode)) {
 						KeyEvent ke = (KeyEvent) event.sourceEvent;
 						ke.doit = false;
 						return true;
 					}
 					
 				}
-				
-				
-				
-				
-				
 				
 				if (event.eventType == ColumnViewerEditorActivationEvent.PROGRAMMATIC && isNameColumn) {
 					focusCellManager.getFocusCell(); //bug, dies stellt aber die Sictbarkeit des Cell-Cursors wieder her
@@ -219,6 +215,30 @@ public class ElementGeneratorWizardPage extends WizardPage {
 				
 				
 				return false;
+			}
+
+			/**
+			 * Returns true if the given keycode has no special function in the modelwizard
+			 * @param keyCode
+			 * @return boolean
+			 */
+			private boolean isNotDifferentUsedKey(int keyCode) {
+				if (keyCode == SWT.ALT) {
+					return false;
+				}
+				if (keyCode == SWT.ARROW_DOWN) {
+					return false;
+				}
+				if (keyCode == SWT.ARROW_UP) {
+					return false;
+				}
+				if (keyCode == SWT.ARROW_RIGHT) {
+					return false;
+				}
+				if (keyCode == SWT.ARROW_LEFT) {
+					return false;
+				}
+				return true;
 			}
 		};
 		

--- a/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/modelwizard/pages/ElementGeneratorWizardPage.java
+++ b/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/modelwizard/pages/ElementGeneratorWizardPage.java
@@ -199,7 +199,6 @@ public class ElementGeneratorWizardPage extends WizardPage {
 					if (event.keyCode == SWT.CR && currentColumn%2 == 0 && currentColumn != 0) {
 						return true;
 					}
-					//if (isNameColumn && ((event.keyCode >= 48 && event.keyCode <= 57) || (event.keyCode >= 97 && event.keyCode <= 122))) {
 					if (isNameColumn && event.eventType == ColumnViewerEditorActivationEvent.KEY_PRESSED && isNotDifferentUsedKey(event.keyCode)) {
 						KeyEvent ke = (KeyEvent) event.sourceEvent;
 						ke.doit = false;

--- a/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/modelwizard/utils/Connector.java
+++ b/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/modelwizard/utils/Connector.java
@@ -215,7 +215,7 @@ public class Connector
 			case XOR_DOUBLE:
 				return "Alt + w";
 			case XOR_N:
-				return "Alt + c";
+				return "Alt + e";
 			case XOR_IT:
 				return "Alt + r";
 			case NONE:

--- a/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/wizards/ModelWizard.java
+++ b/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/wizards/ModelWizard.java
@@ -502,12 +502,20 @@ public class ModelWizard extends Wizard {
 					}
 				}
 
-				if (!quickFix)
-					connectionStack.add(new Connection(anchor, getFirstDrawnControlFlowEP()));
+				if (!quickFix){
+					Object target = getFirstDrawnControlFlowEP();
+					if (target != null) {
+						connectionStack.add(new Connection(anchor, getFirstDrawnControlFlowEP()));
+					}
+				}
+				
 			}
 
 			if (connectionStack.size() != 0 && countArcConnections(anchor.getSourceConnections()) == 0 && !quickFix) {
-				connectionStack.add(new Connection(anchor, getFirstDrawnControlFlowEP()));
+				Object target = getFirstDrawnControlFlowEP();
+				if (target != null) {
+					connectionStack.add(new Connection(anchor, getFirstDrawnControlFlowEP()));
+				}
 			}
 		}
 	}

--- a/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/wizards/ModelWizard.java
+++ b/plugins/org.bflow.toolbox.epc.diagram/src/org/bflow/toolbox/epc/diagram/wizards/ModelWizard.java
@@ -6,10 +6,13 @@ import java.util.Stack;
 import java.util.UUID;
 import java.util.Vector;
 
+import org.bflow.toolbox.epc.diagram.edit.parts.ANDEditPart;
 import org.bflow.toolbox.epc.diagram.edit.parts.ArcEditPart;
 import org.bflow.toolbox.epc.diagram.edit.parts.EpcEditPart;
 import org.bflow.toolbox.epc.diagram.edit.parts.EventEditPart;
 import org.bflow.toolbox.epc.diagram.edit.parts.FunctionEditPart;
+import org.bflow.toolbox.epc.diagram.edit.parts.OREditPart;
+import org.bflow.toolbox.epc.diagram.edit.parts.XOREditPart;
 import org.bflow.toolbox.epc.diagram.modelwizard.pages.ElementGeneratorWizardPage;
 import org.bflow.toolbox.epc.diagram.modelwizard.utils.Connector;
 import org.bflow.toolbox.epc.diagram.modelwizard.utils.Constants;
@@ -543,7 +546,7 @@ public class ModelWizard extends Wizard {
 	private Object getFirstDrawnControlFlowEP(){
 		for (Connection con : connectionStack) {
 			Object ep = con.getSource();
-			if (ep instanceof FunctionEditPart || ep instanceof EventEditPart) {
+			if (ep instanceof FunctionEditPart || ep instanceof EventEditPart || ep instanceof ANDEditPart || ep instanceof OREditPart || ep instanceof XOREditPart) {
 				return con.getSource();
 			}
 		}


### PR DESCRIPTION
 Bugfixes

Namensfelder werden jetzt bei jedem Tastendruck aktiviert und werden so zum Beschreiben aktiviert (ausgenommen Cursortasten und ALT)

Falsche Beschriftung für die Schnellwahl-Konnektorauswahl korrigiert

Wird ein erstelltes Modell an ein bestehendes angeknüpft werden nun auch
Konnektoren berücksichtigt.
